### PR TITLE
Add Figment.so to Prototyping tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 * [Marvel App](https://marvelapp.com/): Free mobile & web prototyping for designers.
 * [Atomic.io](https://atomic.io/): Free in Browser interactive design Tool.
 * [Flinto](https://www.flinto.com/):  App to create interactive and animated prototypes of designs.
+* [Figment](https://figment.so/): Turn your Figma designs into fully function web apps with no-code.
 
 ## Tutorials
 * [Treehouse](https://teamtreehouse.com/tracks/web-design): Brings affordable, technology education to people everywhere.


### PR DESCRIPTION
Figment.so is a productivity tool that allows you to turn your Figma designs into functional websites without code.

I argue it should be on the list because it can rapidly speed up prototyping via Figma for design teams & getting approvals for application flows.

- [x] I read & followed the contribution guidelines.